### PR TITLE
Fix APNG playback count for loop states

### DIFF
--- a/routes/apng/tools/README.md
+++ b/routes/apng/tools/README.md
@@ -95,6 +95,7 @@ node gen-video.js idle-yawn --image reference/main-ref.png --last-frame referenc
 
 `--last-frame` 是**尾帧锚定**——告诉 AI 视频结束时的形态。这是保证循环无缝的关键技巧。
 省略时，循环和回归型状态会自动复用 `--image`；过渡型状态必须显式提供不同的尾帧。
+自动后处理会读取状态的 `loop` 字段：循环状态生成无限播放 APNG，一次性状态只播放一遍。
 
 ### 第 3 步：批量生成（带限流）
 

--- a/routes/apng/tools/gen-video.js
+++ b/routes/apng/tools/gen-video.js
@@ -14,6 +14,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { doubaoGenerateVideo, downloadBuffer } from './lib/api.js';
+import { buildChromaInvocation } from './lib/chroma-command.js';
 import { ANIMATIONS, buildPrompt } from './prompts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -182,11 +183,13 @@ if (!skipChroma && results.length > 0) {
       const apngPath = videoPath.replace('.mp4', '.apng');
       try {
         console.log(`  处理: ${videoPath}`);
-        const python = process.platform === 'win32' ? 'py' : 'python3';
-        const pythonArgs = process.platform === 'win32'
-          ? ['-3', chromaScript, videoPath, apngPath]
-          : [chromaScript, videoPath, apngPath];
-        const processed = spawnSync(python, pythonArgs, {
+        const invocation = buildChromaInvocation({
+          scriptPath: chromaScript,
+          videoPath,
+          apngPath,
+          loop: anim.loop,
+        });
+        const processed = spawnSync(invocation.command, invocation.args, {
           stdio: 'inherit',
           cwd: __dirname,
         });

--- a/routes/apng/tools/lib/chroma-command.js
+++ b/routes/apng/tools/lib/chroma-command.js
@@ -1,0 +1,27 @@
+/**
+ * Build the platform-specific chroma-key command.
+ *
+ * APNG uses 0 for infinite playback and 1 for a single play.
+ */
+export function buildChromaInvocation({
+  platform = process.platform,
+  scriptPath,
+  videoPath,
+  apngPath,
+  loop,
+}) {
+  const plays = loop ? '0' : '1';
+  const args = [scriptPath, videoPath, apngPath, '--plays', plays];
+
+  if (platform === 'win32') {
+    return {
+      command: 'py',
+      args: ['-3', ...args],
+    };
+  }
+
+  return {
+    command: 'python3',
+    args,
+  };
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import { ANIMATIONS, buildGenVideoCommand } from '../routes/apng/prompts/template.js';
+import { buildChromaInvocation } from '../routes/apng/tools/lib/chroma-command.js';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const tools = join(root, 'routes', 'apng', 'tools');
@@ -27,7 +28,32 @@ for (const [key, anim] of Object.entries(ANIMATIONS)) {
   const command = buildGenVideoCommand(key, refs);
   const expectedLastFrame = anim.anchor === 'same' ? refs[anim.refKey] : refs[anim.lastKey];
   assert.ok(command.includes(`--last-frame ${expectedLastFrame}`), `${key} has the wrong last-frame anchor`);
+  const chromaInvocation = buildChromaInvocation({
+    platform: 'darwin',
+    scriptPath: 'chroma_key.py',
+    videoPath: `${key}.mp4`,
+    apngPath: `${key}.apng`,
+    loop: anim.loop,
+  });
+  assert.deepEqual(chromaInvocation, {
+    command: 'python3',
+    args: ['chroma_key.py', `${key}.mp4`, `${key}.apng`, '--plays', anim.loop ? '0' : '1'],
+  });
 }
+
+assert.deepEqual(
+  buildChromaInvocation({
+    platform: 'win32',
+    scriptPath: 'chroma_key.py',
+    videoPath: 'input.mp4',
+    apngPath: 'output.apng',
+    loop: false,
+  }),
+  {
+    command: 'py',
+    args: ['-3', 'chroma_key.py', 'input.mp4', 'output.apng', '--plays', '1'],
+  },
+);
 
 const cleanEnv = { ...process.env, DOUBAO_API_KEY: '', DOUBAO_BASE_URL: '' };
 function expectExit(args, expected, outputPattern) {


### PR DESCRIPTION
## Summary

- pass APNG playback count from each animation loop flag during automatic chroma-key post-processing
- generate infinite-play APNGs for loop states and single-play APNGs for one-shot states
- keep the Windows and macOS/Linux Python invocation paths explicit and directly testable
- validate the mapping across all 25 animation states and document the behavior

## Why

During the real end-to-end validation of #1, an idle-dozing APNG was generated successfully but retained the chroma-key default of plays=1. That made a loop state play only once. One-shot and transition states should continue to use plays=1, while loop states need plays=0.

## Validation

- npm test --prefix routes/apng/tools
- python3 routes/apng/tools/test_image_safety.py
- reprocessed the real 121-frame validation MP4 into two 41-frame APNGs
  - loop output reported plays=0
  - one-shot output reported plays=1

No additional generation API call was needed for this follow-up.