### PR TITLE
Fix arbitrary chroma key handling in APNG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pet-forge 可以作为独立工具包使用，也可以作为 Codex skill 使用
 参考图                               prompt 模板
    -> 去背景                            -> AI 参考图
    -> PNG 转 SVG                        -> 首尾帧锚定的 AI 视频
-   -> preset + SVG 模板                 -> 绿幕抠图
+   -> preset + SVG 模板                 -> 纯色色键抠图
    -> 自包含 .svg.html                  -> .apng
 ```
 
@@ -154,10 +154,16 @@ node gen-images.js --prompt "A cute chibi ..." --output reference/main-ref.png -
 node gen-video.js idle-dozing --image reference/main-ref.png --last-frame reference/main-ref.png --api doubao
 ```
 
-如果需要手动重跑绿幕抠图：
+默认色键是绿色 `#00B140`。角色本身含绿色时，选一个与角色不冲突的颜色，并让视频 prompt 和自动后处理共用该值：
 
 ```powershell
-py chroma_key.py output/idle-dozing/doubao-video.mp4 output/idle-dozing/result.apng --plays 0
+node gen-video.js thinking --image reference/main-ref.png --last-frame reference/main-ref.png --api doubao --key-color "#FF00FF"
+```
+
+如果需要手动重跑色键抠图：
+
+```powershell
+py chroma_key.py output/thinking/doubao-video.mp4 output/thinking/result.apng --plays 0 --key-color "#FF00FF"
 ```
 
 ## 仓库结构

--- a/SKILL.md
+++ b/SKILL.md
@@ -151,7 +151,7 @@ py -3.13 -m rembg i input.png input-clean.png
 引导用户：
 - 写 CHARACTER_PREFIX（参考 `routes/apng/prompts/template.js` 模板）
 - 生 1 张主参考图（gen-images.js 或 ChatGPT 网页）
-- 检验：标准姿势 / 中性表情 / 纯绿幕 #00B140
+- 检验：标准姿势 / 中性表情 / 与角色颜色不冲突的纯色色键（默认 #00B140）
 
 ### 第 2 步：环境配置
 

--- a/routes/apng/conventions/workflow.md
+++ b/routes/apng/conventions/workflow.md
@@ -17,12 +17,12 @@
    │  CHARACTER_PREFIX + 动作描述 + BG_SUFFIX
    ▼
 [3. 生视频]
-   │  gen-video.js (--last-frame 锚定) → mp4 (绿幕背景)
+   │  gen-video.js (--last-frame 锚定) → mp4 (纯色色键背景)
    ▼
 [4. 检查 + 重生]
    │  循环节奏 OK ? 动作 OK ? 翻车就重跑
    ▼
-[5. 绿幕抠图 → APNG]
+[5. 色键抠图 → APNG]
    │  chroma_key.py
    ▼
 [6. APNG 后处理（可选）]
@@ -67,7 +67,7 @@ node gen-images.js --prompt "<CHARACTER_PREFIX 的具体填好版本>" --output 
 - 标准坐姿 / 站姿（最中性，能转换到其他状态）
 - 眼睛**睁开**（闭眼参考图无法做 idle）
 - 表情**中性**（笑/哭/惊讶都不适合做主参考）
-- 背景**纯绿幕** `#00B140` 或 `#00FF00`
+- 背景使用与角色颜色不冲突的**纯色色键**；默认是绿色 `#00B140`
 
 ---
 
@@ -78,7 +78,7 @@ node gen-images.js --prompt "<CHARACTER_PREFIX 的具体填好版本>" --output 
 ```
 [CHARACTER_PREFIX] —— 角色外观（所有状态共享）
 [动作描述]         —— 这个状态做什么
-[BG_SUFFIX]       —— 背景要求（绿幕保持纯色）
+[BG_SUFFIX]       —— 背景要求（色键保持纯色）
 ```
 
 ### 动作描述写法
@@ -137,7 +137,7 @@ node gen-video.js \
 
 - [ ] 角色形态跟参考图一致
 - [ ] 动作描述被正确执行
-- [ ] 背景全程纯绿幕（无阴影、无遮挡）
+- [ ] 背景全程保持选定的纯色色键（无阴影、无遮挡）
 - [ ] 循环类：首尾帧位置 + 形态对齐（容差 ±5px）
 - [ ] 一次性类：结尾回到中性姿态
 
@@ -148,13 +148,13 @@ node gen-video.js \
 | 角色变形 / 不像参考图 | 重跑，加强 CHARACTER_PREFIX |
 | 尾巴 / 触角 / 耳朵爆炸放大 | prompt 加 "DO NOT inflate" negative |
 | 镜头平移 / 旋转 | prompt 加 "Camera stays still" |
-| 背景出现物体 / 阴影 | prompt 加 "Background must remain pure green" |
+| 背景出现物体 / 阴影 | prompt 加 "Background must remain a uniform solid key-color" |
 | 首尾帧错位 | `--last-frame` 锚定，prompt 强调 "Seamless loop" |
 | 帧数过少 / 跳帧 | 调长 duration 或换更稳定的可用模型 |
 
 ---
 
-## 第 5 步：绿幕抠图 → APNG
+## 第 5 步：色键抠图 → APNG
 
 ```powershell
 py chroma_key.py output/idle/raw.mp4 output/idle/result.apng --plays 0
@@ -162,9 +162,9 @@ py chroma_key.py output/idle/raw.mp4 output/idle/result.apng --plays 0
 
 `--plays 0` = 无限循环，`--plays 1` = 单次播放（默认）。
 
-### 绿幕颜色一致性
+### 色键颜色一致性
 
-视频生成时 prompt 指定 `#00B140`，但 AI 生出来可能略有偏差（`#00B042` / `#00B23E`...）。`chroma_key.py` 默认 tolerance=50 能容忍这种偏差。极端情况调到 70。
+默认 prompt 指定 `#00B140`，但 AI 生出来可能略有偏差（`#00B042` / `#00B23E`...）。`chroma_key.py` 默认 tolerance=50 能容忍这种偏差。角色本身含绿色时，应在 `gen-video.js` 传入另一个 `--key-color`；该值会同时用于 prompt 和自动后处理。极端情况可以在采样实际背景后调高 tolerance。
 
 ---
 
@@ -212,7 +212,7 @@ py chroma_key.py output/idle/raw.mp4 output/idle/result.apng --plays 0
 1. **角色一致性 > prompt 详细度**：CHARACTER_PREFIX 写好一次，所有状态都受益
 2. **循环靠 `--last-frame`**：尾帧锚定是 APNG 路线的关键能力
 3. **失败重跑是常态**：不要试图"修"失败的视频，直接重跑
-4. **绿幕颜色统一**：参考图、prompt、抠图工具用同一个绿色（#00B140 推荐）
+4. **色键颜色统一**：参考图、prompt、抠图工具使用同一个、且不与角色冲突的颜色
 5. **批量生成带间隔**：`batch-gen.js` 的 60s 间隔不是冗余，是必须
 6. **prompt 最后强调一次起止姿态**：放在 prompt 最后效果最好
 7. **mini 状态另写 prompt**：mini-idle 不是 idle 的缩小版，是不同姿态

--- a/routes/apng/lessons/pitfalls.md
+++ b/routes/apng/lessons/pitfalls.md
@@ -68,7 +68,7 @@ AI 视频生成最常见 4 类翻车，每类都有专属 negative prompt：
 | 尾巴 / 触角爆炸性放大 | `DO NOT inflate or balloon the {tail/antenna/etc.}` |
 | 镜头平移 / 旋转 | `Camera stays completely still. DO NOT rotate or shift the camera angle.` |
 | 加人手 / 道具 | `NO hands, NO fingers, NO human body parts visible.` |
-| 背景出现物体 / 阴影 | `The background must remain a uniform solid green. No shadows, no objects, no gradients.` |
+| 背景出现物体 / 阴影 | `The background must remain a uniform solid key-color. No shadows, no objects, no gradients.` |
 
 **写在 prompt 末尾效果最好**（AI 对末尾指令敏感）。
 
@@ -112,16 +112,16 @@ mini 模式的语义是"在 dock / tray 角落不显眼"，姿态本身就该是
 
 ---
 
-### 8. 绿幕颜色全链路一致
+### 8. 色键颜色全链路一致
 
 **现象**：参考图绿幕是 `#00FF00`，prompt 写 `#00B140`，抠图工具默认 `#00B140`，结果绿边抠不干净。
 
-**正确做法**：开工前**定一个绿幕颜色**，全链路统一；如果生成视频的实际绿幕偏色，以输出视频里采样到的真实背景色为准：
-- 参考图：使用同一绿幕色
-- prompt：写同一绿幕色，并要求 uniform solid green
+**正确做法**：开工前**定一个色键颜色**，全链路统一；如果生成视频的实际背景偏色，以输出视频里采样到的真实背景色为准：
+- 参考图：使用同一色键
+- prompt：写同一颜色，并要求 uniform solid background
 - chroma_key 配置：用参考色或从视频采样出的真实色
 
-**推荐 `#00B140`**：比 `#00FF00` 不容易跟黄绿色花纹冲突。
+默认推荐 `#00B140`。角色本身含绿色时，改用与角色分离的颜色，例如 `#FF00FF`，并通过 `gen-video.js --key-color` 贯穿 prompt 与抠图。不要只改 `chroma_key.py` 的参数而让视频继续生成另一种背景色。
 
 ---
 
@@ -144,14 +144,14 @@ mini 模式的语义是"在 dock / tray 角落不显眼"，姿态本身就该是
 
 状态数越多，等待、重跑和人工检验成本会线性放大。先做 1 个 hero 状态，确认路线可行后再扩展。
 
-### 11. 绿幕 prompt 要禁止速度线和地面线索
+### 11. 色键 prompt 要禁止速度线和地面线索
 
 **现象**：角色动作不错，但背景出现速度线、投影、地面、烟尘或光效，抠图后留下脏边。
 
 **正确做法**：prompt 末尾显式写：
 
 ```text
-Uniform solid green background only. No shadows, no floor, no speed lines, no motion streaks, no particles, no props, no camera movement.
+Uniform solid key-color background only. No shadows, no floor, no speed lines, no motion streaks, no particles, no props, no camera movement.
 ```
 
 对走路、爬行、跳跃这类横向动作，优先让角色做 treadmill motion：肢体在动，但身体中心基本留在画面中央。真正的窗口位移交给 host。
@@ -170,7 +170,7 @@ Uniform solid green background only. No shadows, no floor, no speed lines, no mo
 
 预览和定稿分两档：
 
-- 快速预览：先用工具默认档，确认动作、构图、绿幕是否值得继续；
+- 快速预览：先用工具默认档，确认动作、构图、色键背景是否值得继续；
 - 定稿前：试一次更高质量档，例如 `--height 400 --max-colors 256 --fps 12`；
 - 如果体积过大，再按目标 runtime 的限制回调 height、fps 或 colors。
 
@@ -183,7 +183,7 @@ Uniform solid green background only. No shadows, no floor, no speed lines, no mo
 - ❌ **不写 CHARACTER_PREFIX 直接写动作 prompt**：每次生成长得不一样
 - ❌ **循环类不用尾帧锚定**：首尾姿态很容易对不齐
 - ❌ **失败视频强行 ffmpeg 修**：时间成本高于重跑
-- ❌ **绿幕颜色不统一**：抠图阶段必出问题
+- ❌ **色键颜色不统一**：抠图阶段必出问题
 - ❌ **Prompt 没 negative 段**：AI 翻车 4 大类必踩 1-2 个
 - ❌ **批量生成不带间隔**：限流 429 死循环
 - ❌ **Mini 状态当 main 的缩小版**：mini 应该是不同姿态

--- a/routes/apng/prompts/template.js
+++ b/routes/apng/prompts/template.js
@@ -36,7 +36,7 @@
 // - 颜色 / 花纹（cream body with orange patches / metallic gray ...）
 // - 主要识别特征（big round eyes with white highlights / small triangle ears ...）
 // - 描边 / 渲染风格（thick dark outlines / cell-shaded / NO 3D rendering ...）
-// - 背景要求（plain solid green #00B140 background）
+// - 背景要求（与角色颜色分离的纯色色键；默认 #00B140）
 //
 export const CHARACTER_PREFIX = `[在这里写你的角色外观描述。例如：
 A cute chibi/kawaii style {物种} character with {描边特征}, {体型特征},
@@ -45,8 +45,22 @@ has {主体颜色}, {主要特征 1}, {主要特征 2}, {表情特征}. The art 
 is clean vector cartoon — NO pixel art, NO realistic rendering, NO 3D.
 Consistent character design throughout, no color changes between frames.]`;
 
-// ── 2. 绿幕背景强调（一般不用改） ────────────────────────────
-export const BG_SUFFIX = `The background must remain a uniform solid green (#00B140) throughout the entire video. No shadows, no objects, no gradients on the background.`;
+// ── 2. 色键背景强调（一般不用改） ────────────────────────────
+export const DEFAULT_KEY_COLOR = '#00B140';
+export const BG_SUFFIX = `The background must remain a uniform solid green (${DEFAULT_KEY_COLOR}) throughout the entire video. No shadows, no objects, no gradients on the background.`;
+
+export function normalizeKeyColor(value = DEFAULT_KEY_COLOR) {
+  if (typeof value !== 'string' || !/^#[0-9a-f]{6}$/i.test(value)) {
+    throw new Error('key color must use #RRGGBB format');
+  }
+  return value.toUpperCase();
+}
+
+export function buildBackgroundSuffix(keyColor = DEFAULT_KEY_COLOR) {
+  const normalized = normalizeKeyColor(keyColor);
+  if (normalized === DEFAULT_KEY_COLOR) return BG_SUFFIX;
+  return `The background must remain a uniform solid color (${normalized}) throughout the entire video. No shadows, no objects, no gradients on the background.`;
+}
 
 // ── 3. 完整状态库（25 个交付状态，按通用 state-mapping 分类） ────
 //
@@ -331,13 +345,19 @@ export const ANIMATIONS = {
 };
 
 // ── 4. 拼接函数（生成最终 prompt 给 API） ────────────────────
-export function buildFullPrompt(animationKey) {
+export function buildFullPrompt(animationKey, { keyColor = DEFAULT_KEY_COLOR } = {}) {
   const anim = ANIMATIONS[animationKey];
   if (!anim) {
     const keys = Object.keys(ANIMATIONS).join(', ');
     throw new Error(`未知动画: "${animationKey}"。可选: ${keys}`);
   }
-  return `${CHARACTER_PREFIX}\n\n${anim.prompt}\n\n${BG_SUFFIX}`;
+  const normalizedKeyColor = normalizeKeyColor(keyColor);
+  const characterPrefix = normalizedKeyColor === DEFAULT_KEY_COLOR
+    ? CHARACTER_PREFIX
+    : CHARACTER_PREFIX
+      .replaceAll(DEFAULT_KEY_COLOR, normalizedKeyColor)
+      .replaceAll('plain solid green', 'plain solid color');
+  return `${characterPrefix}\n\n${anim.prompt}\n\n${buildBackgroundSuffix(normalizedKeyColor)}`;
 }
 
 // ── 5. 列出所有动画（按首尾帧关系分组） ──────────────────────
@@ -365,7 +385,7 @@ export function listAnimations() {
 }
 
 // ── 6. 生成 gen-video.js 命令（按 anchor 类型自动选项） ─────
-export function buildGenVideoCommand(animationKey, refImagePaths) {
+export function buildGenVideoCommand(animationKey, refImagePaths, { keyColor } = {}) {
   const anim = ANIMATIONS[animationKey];
   if (!anim) throw new Error(`未知动画: ${animationKey}`);
 
@@ -388,6 +408,10 @@ export function buildGenVideoCommand(animationKey, refImagePaths) {
     const lastPath = refImagePaths[anim.lastKey];
     if (!lastPath) throw new Error(`lastKey "${anim.lastKey}" 没有对应路径`);
     parts.push(`--last-frame ${lastPath}`);
+  }
+
+  if (keyColor) {
+    parts.push(`--key-color "${normalizeKeyColor(keyColor)}"`);
   }
 
   parts.push(`--no-chroma`);

--- a/routes/apng/tools/README.md
+++ b/routes/apng/tools/README.md
@@ -1,14 +1,14 @@
 # APNG 路线工具集
 
 > 来源：pet-forge 的公开 APNG 路线辅助工具。
-> 用途：用 AI 视频生成 + 绿幕抠图做出 APNG 桌宠动画。
+> 用途：用 AI 视频生成 + 纯色色键抠图做出 APNG 桌宠动画。
 
 ---
 
 ## 完整管线
 
 ```
-prompt 模板  →  AI 生参考图  →  AI 生视频(尾帧锚定)  →  绿幕抠图  →  APNG
+prompt 模板  →  AI 生参考图  →  AI 生视频(尾帧锚定)  →  色键抠图  →  APNG
    ↑              ↓              ↓                    ↓
 prompts/   gen-images.js  gen-video.js           chroma_key.py
                                                        ↓
@@ -113,15 +113,16 @@ node batch-gen.js --config animations.json
       "key": "idle-yawn",
       "image": "reference/main-ref.png",
       "lastFrame": "reference/main-ref.png",
-      "api": "doubao"
+      "api": "doubao",
+      "keyColor": "#FF00FF"
     }
   ]
 }
 ```
 
-### 第 4 步：绿幕抠图 → APNG
+### 第 4 步：色键抠图 → APNG
 
-视频用绿幕背景（`#00B140` 或 `#00FF00`）：
+默认视频使用绿幕背景 `#00B140`：
 
 ```powershell
 py chroma_key.py output/idle-yawn/doubao-video.mp4 output/idle-yawn/result.apng
@@ -129,12 +130,20 @@ py chroma_key.py output/idle-yawn/doubao-video.mp4 output/idle-yawn/result.apng
 
 支持参数：
 - `--plays 0` —— 0 = 无限循环, 1 = 单次播放（默认）
-- `--key-color "#00B140"` —— 绿幕颜色
+- `--key-color "#00B140"` —— 色键颜色，接受任意 `#RRGGBB`
 - `--tolerance 50` —— 颜色容差
+
+角色本身含绿色时，可以让生成 prompt 和自动后处理一起改用洋红：
+
+```powershell
+node gen-video.js thinking --image reference/main-ref.png --last-frame reference/main-ref.png --key-color "#FF00FF"
+```
+
+显式 `--key-color` 会同时更新视频背景要求，并传给 `chroma_key.py`。抠图只按指定颜色及其容差工作，不会继续额外删除绿色。
 
 ### 第 5 步：APNG 后处理（可选）
 
-如果绿边抠不干净：
+如果色键边缘抠不干净：
 
 ```powershell
 py fix_gray_bleed.py output/idle-yawn/frames output/idle-yawn/frames-fixed
@@ -166,7 +175,7 @@ py rebuild_apng.py output/idle-yawn/frames-fixed output/idle-yawn/result.apng --
 | `lib/api.js` | API 客户端封装（Doubao / Volcengine） |
 | `test-api.js` | API 连通性测试 |
 | `preview.html` | 本地预览页（拖入 APNG/视频/图片即看） |
-| `chroma_key.py` | 绿幕抠图 → APNG（`--plays 1` 单次, `--plays 0` 无限） |
+| `chroma_key.py` | 纯色色键抠图 → APNG（`--plays 1` 单次, `--plays 0` 无限） |
 | `check_dark.py` | 检查 PNG 帧目录是否有暗色泄漏 |
 | `fix_gray_bleed.py` | 只清理透明边缘相邻的半透明冷灰溢出，保留不透明角色灰色 |
 | `rebuild_apng.py` | 从 PNG 帧目录重建 APNG（修压缩/改帧率） |
@@ -185,9 +194,9 @@ py rebuild_apng.py output/idle-yawn/frames-fixed output/idle-yawn/result.apng --
 - prompt 里强调 "Seamless loop animation — the last frame connects perfectly back to the first frame"
 - 实在对不齐，用 ffmpeg 剪辑掉前 5-10 帧或后 5-10 帧再做 APNG
 
-### 绿边抠不干净
+### 色键边缘抠不干净
 
-- 检查视频背景颜色是否一致（用 `check_dark.py` 看）
+- 检查视频背景颜色是否一致，并从实际视频采样色键
 - 调 `chroma_key.py` 的 `--tolerance`（默认 50，可加到 70）
 - 实在不行，用 `fix_gray_bleed.py` 后处理
 

--- a/routes/apng/tools/batch-gen.js
+++ b/routes/apng/tools/batch-gen.js
@@ -35,7 +35,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 function usage(exitCode = 0) {
   console.log('Usage: node batch-gen.js --config <batch.json> [--only <animation-key>]');
   console.log('');
-  console.log('Each job accepts: key, image, lastFrame, api, model, refMode, noFirstFrame, noChroma, extraArgs.');
+  console.log('Each job accepts: key, image, lastFrame, api, model, keyColor, refMode, noFirstFrame, noChroma, extraArgs.');
   console.log('The public example API value is currently doubao.');
   process.exit(exitCode);
 }
@@ -88,6 +88,7 @@ function buildCommand(job, index, baseDir) {
   if (lastFrame) cmdArgs.push('--last-frame', lastFrame);
   if (job.api) cmdArgs.push('--api', job.api);
   if (job.model) cmdArgs.push('--model', job.model);
+  if (job.keyColor) cmdArgs.push('--key-color', job.keyColor);
   if (job.refMode) cmdArgs.push('--ref-mode');
   if (job.noFirstFrame) cmdArgs.push('--no-first-frame');
   if (job.noChroma || job.chroma === false) cmdArgs.push('--no-chroma');

--- a/routes/apng/tools/chroma_key.py
+++ b/routes/apng/tools/chroma_key.py
@@ -1,4 +1,4 @@
-"""Chroma key (green screen removal) for APNG animation pipelines.
+"""Solid-color chroma key removal for APNG animation pipelines.
 
 Usage:
   python chroma_key.py <input_video> [output_apng] [--plays 0]
@@ -23,12 +23,6 @@ MAX_COLORS = 192
 PLAYS = 1          # 1 = play once, 0 = loop forever
 DEFAULT_KEY_RGB = (0, 177, 64)
 
-# Green screen HSV range (tuned for #00B140 ± tolerance)
-HUE_MIN, HUE_MAX = 80, 160       # green hue range on a 0-360 scale
-SAT_MIN = 40                      # minimum saturation to count as "green"
-BRIGHT_MIN = 30                   # minimum brightness
-
-
 def parse_key_color(value: str) -> tuple[int, int, int]:
     raw = value.strip()
     if raw.startswith("#"):
@@ -50,63 +44,42 @@ def chroma_key_frame(
     arr = np.array(img.convert('RGBA'))
     r, g, b, a = arr[:,:,0], arr[:,:,1], arr[:,:,2], arr[:,:,3]
 
-    # Convert to float HSV manually (avoid opencv dependency)
-    rf, gf, bf = r / 255.0, g / 255.0, b / 255.0
-    cmax = np.maximum(rf, np.maximum(gf, bf))
-    cmin = np.minimum(rf, np.minimum(gf, bf))
-    delta = cmax - cmin
-
-    # Hue (0-360)
-    hue = np.zeros_like(rf)
-    mask_r = (cmax == rf) & (delta > 0)
-    mask_g = (cmax == gf) & (delta > 0)
-    mask_b = (cmax == bf) & (delta > 0)
-    hue[mask_r] = 60 * (((gf[mask_r] - bf[mask_r]) / delta[mask_r]) % 6)
-    hue[mask_g] = 60 * (((bf[mask_g] - rf[mask_g]) / delta[mask_g]) + 2)
-    hue[mask_b] = 60 * (((rf[mask_b] - gf[mask_b]) / delta[mask_b]) + 4)
-
-    # Saturation (0-100)
-    sat = np.zeros_like(cmax)
-    np.divide(delta, cmax, out=sat, where=cmax > 0)
-    sat *= 100
-
-    # Value/Brightness (0-100)
-    val = cmax * 100
-
-    # Green mask: pixels that are green enough by hue, or close to the requested key color.
+    # Measure only distance from the requested key. The previous implementation
+    # always ORed in a broad green-hue mask and always despilled green, so using
+    # --key-color with magenta still erased legitimate green subjects.
     key_r, key_g, key_b = [float(c) for c in key_rgb]
     dist_to_key = np.sqrt(
         (r.astype(float) - key_r) ** 2 +
         (g.astype(float) - key_g) ** 2 +
         (b.astype(float) - key_b) ** 2
     )
-    is_hsv_green = (hue >= HUE_MIN) & (hue <= HUE_MAX) & (sat >= SAT_MIN) & (val >= BRIGHT_MIN)
     is_key_color = dist_to_key <= tolerance
-    is_green = is_hsv_green | is_key_color
 
-    # Soft edge: pixels near green get partial transparency
-    # Calculate "greenness" score for anti-aliased edges
-    green_ratio = gf / (rf + gf + bf + 0.001)
-    near_key_edge = dist_to_key <= max(tolerance * 1.8, tolerance + 35)
-    is_semi_green = ((green_ratio > 0.45) | near_key_edge) & (sat >= SAT_MIN * 0.5) & ~is_green
+    # Fade pixels between the hard tolerance and a wider edge tolerance. This
+    # handles compression and antialiasing around any requested key color.
+    edge_tolerance = max(tolerance * 1.8, tolerance + 35)
+    is_key_edge = (dist_to_key > tolerance) & (dist_to_key <= edge_tolerance)
+    edge_span = max(edge_tolerance - tolerance, 1.0)
+    edge_coverage = np.clip((dist_to_key - tolerance) / edge_span, 0.0, 1.0)
 
     # Apply
     new_a = a.copy()
-    new_a[is_green] = 0
-    new_a[is_semi_green] = (new_a[is_semi_green] * 0.3).astype(np.uint8)
+    new_a[is_key_color] = 0
+    new_a[is_key_edge] = (
+        new_a[is_key_edge].astype(float) * edge_coverage[is_key_edge]
+    ).astype(np.uint8)
 
-    # Despill: remove green tint from ALL surviving pixels
-    # Any pixel where green dominates more than it should gets corrected
-    surviving = new_a > 0
-    if np.any(surviving):
-        rs, gs, bs = r[surviving].astype(float), g[surviving].astype(float), b[surviving].astype(float)
-        avg_rb = (rs + bs) / 2
-        # If green exceeds the average of R and B, cap it
-        too_green = gs > avg_rb
-        if np.any(too_green):
-            corrected_g = gs.copy()
-            corrected_g[too_green] = avg_rb[too_green] * 0.85 + gs[too_green] * 0.15
-            arr[:,:,1][surviving] = np.clip(corrected_g, 0, 255).astype(np.uint8)
+    # Remove key-color spill from partially transparent edge pixels. Assuming
+    # observed = coverage * foreground + (1 - coverage) * key, solve for the
+    # foreground color. Restrict this to the edge band so opaque subject colors
+    # remain byte-for-byte unchanged.
+    recoverable_edge = is_key_edge & (edge_coverage > 0.05)
+    if np.any(recoverable_edge):
+        coverage = edge_coverage[recoverable_edge]
+        observed = arr[:, :, :3][recoverable_edge].astype(float)
+        key = np.array(key_rgb, dtype=float)
+        recovered = (observed - (1.0 - coverage[:, None]) * key) / coverage[:, None]
+        arr[:, :, :3][recoverable_edge] = np.clip(recovered, 0, 255).astype(np.uint8)
 
     # Also erode alpha edges by 1px to remove any remaining fringe
     from PIL import ImageFilter

--- a/routes/apng/tools/gen-video.js
+++ b/routes/apng/tools/gen-video.js
@@ -15,7 +15,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { doubaoGenerateVideo, downloadBuffer } from './lib/api.js';
 import { buildChromaInvocation } from './lib/chroma-command.js';
-import { ANIMATIONS, buildPrompt } from './prompts.js';
+import { ANIMATIONS, buildPrompt, DEFAULT_KEY_COLOR, normalizeKeyColor } from './prompts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -30,6 +30,7 @@ if (args.length === 0) {
   console.log('  --last-frame <路径> 尾帧参考图片（循环/回归型通常同 --image）');
   console.log('  --api doubao        选择 API（当前公开版仅保留 doubao）');
   console.log('  --model <模型名>    覆盖默认视频模型');
+  console.log(`  --key-color <#RRGGBB> 视频背景和抠图颜色（默认 ${DEFAULT_KEY_COLOR}）`);
   console.log('  --ref-mode          图片作为角色参考，不锚定首帧');
   console.log('  --no-first-frame    不设首帧，只设尾帧');
   console.log('  --no-chroma         跳过 chroma_key 后处理');
@@ -39,6 +40,14 @@ if (args.length === 0) {
 function getArg(flag, defaultVal) {
   const idx = args.indexOf(flag);
   return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : defaultVal;
+}
+
+function requireOptionValue(flag) {
+  const idx = args.indexOf(flag);
+  if (idx >= 0 && (idx + 1 >= args.length || args[idx + 1].startsWith('--'))) {
+    console.error(`❌ ${flag} 缺少参数值`);
+    process.exit(1);
+  }
 }
 
 function imageDataUri(filePath) {
@@ -51,10 +60,21 @@ const animKey = args[0];
 const imagePath = getArg('--image', null);
 const apiChoice = getArg('--api', 'doubao');
 const modelOpt = getArg('--model', null);
+const keyColorOpt = getArg('--key-color', null);
 const lastFramePath = getArg('--last-frame', null);
 const refMode = args.includes('--ref-mode');
 const noFirstFrame = args.includes('--no-first-frame');
 const skipChroma = args.includes('--no-chroma');
+
+requireOptionValue('--key-color');
+
+let keyColor;
+try {
+  keyColor = normalizeKeyColor(keyColorOpt || DEFAULT_KEY_COLOR);
+} catch (err) {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+}
 
 if (apiChoice !== 'doubao') {
   throw new Error('当前公开版仅保留 --api doubao');
@@ -93,7 +113,7 @@ if (refMode && noFirstFrame) {
   process.exit(1);
 }
 
-const prompt = buildPrompt(animKey);
+const prompt = buildPrompt(animKey, { keyColor });
 
 // ── Output setup ─────────────────────────────────────────
 
@@ -102,6 +122,7 @@ const outDir = path.join(__dirname, 'output', animKey);
 console.log(`\n🎬 生成视频: ${animKey} (${anim.name})`);
 console.log(`   首帧图片: ${imagePath || '(none)'}`);
 console.log('   API: doubao');
+console.log(`   色键: ${keyColor}`);
 console.log(`   输出目录: ${outDir}\n`);
 
 // ── Generate video ───────────────────────────────────────
@@ -188,6 +209,7 @@ if (!skipChroma && results.length > 0) {
           videoPath,
           apngPath,
           loop: anim.loop,
+          keyColor,
         });
         const processed = spawnSync(invocation.command, invocation.args, {
           stdio: 'inherit',

--- a/routes/apng/tools/lib/chroma-command.js
+++ b/routes/apng/tools/lib/chroma-command.js
@@ -9,9 +9,11 @@ export function buildChromaInvocation({
   videoPath,
   apngPath,
   loop,
+  keyColor,
 }) {
   const plays = loop ? '0' : '1';
   const args = [scriptPath, videoPath, apngPath, '--plays', plays];
+  if (keyColor) args.push('--key-color', keyColor);
 
   if (platform === 'win32') {
     return {

--- a/routes/apng/tools/prompts.js
+++ b/routes/apng/tools/prompts.js
@@ -7,7 +7,10 @@
 
 export {
   CHARACTER_PREFIX,
+  DEFAULT_KEY_COLOR,
   BG_SUFFIX,
+  normalizeKeyColor,
+  buildBackgroundSuffix,
   ANIMATIONS,
   listAnimations,
   buildGenVideoCommand,

--- a/routes/apng/tools/test_image_safety.py
+++ b/routes/apng/tools/test_image_safety.py
@@ -21,8 +21,37 @@ def load_module(name):
 
 def main():
     chroma_key = load_module("chroma_key")
+    default_green = chroma_key.chroma_key_frame(
+        Image.new("RGBA", (100, 100), (*chroma_key.DEFAULT_KEY_RGB, 255))
+    )
+    assert np.all(np.array(default_green)[:, :, 3] == 0), "default green key was not removed"
+
     red = chroma_key.chroma_key_frame(Image.new("RGBA", (100, 100), (255, 0, 0, 255)))
-    assert np.all(np.array(red)[:, :, 3] == 255), "chroma key erased non-green pixels"
+    assert np.all(np.array(red)[:, :, 3] == 255), "chroma key erased non-key pixels"
+
+    magenta_key = (255, 0, 255)
+    magenta = chroma_key.chroma_key_frame(
+        Image.new("RGBA", (100, 100), (*magenta_key, 255)),
+        key_rgb=magenta_key,
+    )
+    assert np.all(np.array(magenta)[:, :, 3] == 0), "custom magenta key was not removed"
+
+    teal_rgb = (16, 163, 127)
+    teal = chroma_key.chroma_key_frame(
+        Image.new("RGBA", (100, 100), (*teal_rgb, 255)),
+        key_rgb=magenta_key,
+    )
+    teal_pixels = np.array(teal)
+    assert np.all(teal_pixels[:, :, 3] == 255), "magenta key erased a green subject"
+    assert np.all(teal_pixels[:, :, :3] == teal_rgb), "magenta despill changed a green subject"
+
+    soft_magenta = chroma_key.chroma_key_frame(
+        Image.new("RGBA", (100, 100), (255, 70, 255, 255)),
+        key_rgb=magenta_key,
+        tolerance=50,
+    )
+    soft_alpha = np.array(soft_magenta)[:, :, 3]
+    assert np.all((soft_alpha > 0) & (soft_alpha < 255)), "custom key edge did not get soft alpha"
 
     gray_bleed = load_module("fix_gray_bleed")
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -5,7 +5,11 @@ import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-import { ANIMATIONS, buildGenVideoCommand } from '../routes/apng/prompts/template.js';
+import {
+  ANIMATIONS,
+  buildFullPrompt,
+  buildGenVideoCommand,
+} from '../routes/apng/prompts/template.js';
 import { buildChromaInvocation } from '../routes/apng/tools/lib/chroma-command.js';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -55,6 +59,33 @@ assert.deepEqual(
   },
 );
 
+assert.deepEqual(
+  buildChromaInvocation({
+    platform: 'darwin',
+    scriptPath: 'chroma_key.py',
+    videoPath: 'input.mp4',
+    apngPath: 'output.apng',
+    loop: true,
+    keyColor: '#FF00FF',
+  }),
+  {
+    command: 'python3',
+    args: [
+      'chroma_key.py', 'input.mp4', 'output.apng', '--plays', '0',
+      '--key-color', '#FF00FF',
+    ],
+  },
+);
+
+const magentaPrompt = buildFullPrompt('thinking', { keyColor: '#ff00ff' });
+assert.ok(magentaPrompt.includes('#FF00FF'));
+assert.ok(!magentaPrompt.includes('#00B140'));
+assert.doesNotMatch(magentaPrompt, /solid green/i);
+assert.match(
+  buildGenVideoCommand('thinking', refs, { keyColor: '#ff00ff' }),
+  /--key-color "#FF00FF"/,
+);
+
 const cleanEnv = { ...process.env, DOUBAO_API_KEY: '', DOUBAO_BASE_URL: '' };
 function expectExit(args, expected, outputPattern) {
   const result = spawnSync(process.execPath, args, { cwd: tools, env: cleanEnv, encoding: 'utf8' });
@@ -67,6 +98,16 @@ expectExit(['gen-video.js'], 0);
 expectExit(['gen-images.js', '--list'], 0);
 expectExit(['test-api.js'], 1);
 expectExit(['gen-video.js', 'idle-dozing', '--no-first-frame', '--no-chroma'], 1, /必须同时提供 --last-frame/);
+expectExit(
+  ['gen-video.js', 'idle-dozing', '--image', sampleImage, '--key-color', 'FF00FF', '--no-chroma'],
+  1,
+  /#RRGGBB/,
+);
+expectExit(
+  ['gen-video.js', 'idle-dozing', '--image', sampleImage, '--key-color', '--no-chroma'],
+  1,
+  /缺少参数值/,
+);
 expectExit(['gen-video.js', 'idle-dozing', '--image', sampleImage, '--no-chroma'], 1, /DOUBAO_API_KEY 未设置/);
 expectExit(
   ['gen-video.js', 'collapse-sleep', '--image', sampleImage, '--last-frame', sampleImage, '--no-chroma'],


### PR DESCRIPTION
`gen-video.js --key-color "#FF00FF"` previously changed only the explicit RGB comparison. The Python postprocessor still ORed in a broad green mask and applied green despill, so green or teal character details could disappear even when magenta was selected.

This change carries one validated `#RRGGBB` key color through the prompt, batch runner, automatic chroma command, and Python postprocessor. The postprocessor now measures distance only from the selected key and performs key-color spill recovery only inside its soft edge band; the existing `#00B140` default remains available.

Validation:

- `npm test`
- `python3 routes/apng/tools/test_image_safety.py`
- Python compile check with an external cache directory
- Hash Sage magenta keyframe regression: old code erased 15,397 green subject pixels and recolored 325,881; new code changed neither, while removing all 1,027,430 pixels inside the hard magenta tolerance
- Local 24 fps MP4 to APNG run: 8 output frames, infinite-loop metadata, transparent background and opaque subject pixels present
